### PR TITLE
Add DVTPlugInCompatibilityUUIDs for Xcode 6.4 betas 1, 2.

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -38,6 +38,8 @@
 		<string>640F884E-CE55-4B40-87C0-8869546CAB7A</string>
 		<string>AD68E85B-441B-4301-B564-A45E4919A6AD</string>
 		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
+		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
+		<string>8DC44374-2B35-4C57-A6FE-2AD66A36AAD9</string>
 	</array>
 	<key>XC4Compatible</key>
 	<true/>


### PR DESCRIPTION
This includes the new `DVTPlugInCompatibilityUUID` value from the following command: 

```
$ defaults read /Applications/Xcode-beta.app/Contents/Info DVTPlugInCompatibilityUUID
```

The first value is from beta 1, the second from beta 2.

**However**: I can't seem to get this to play nicely with the latest Xcode 6.4 beta. Upon launching Xcode, I get this in the console:

```
4/30/15 8:52:58.946 AM Xcode[16554]: Xcode_copy_line ERROR: Unable to find Cut menu item
4/30/15 8:52:58.946 AM Xcode[16554]: Xcode_copy_line failed to initialize
```

It doesn't appear that the reference to `[NSApp mainMenu]` returns anything, at least when it's called inside of `hookMethods`.

I'm gonna look into this some this morning to see if I can figure anything out, but if you know of a fix for this, that would be awesome!