### PR TITLE
Hook into applicationDidFinishLaunching: in order to get menu item refs.

### DIFF
--- a/Xcode_copy_line.m
+++ b/Xcode_copy_line.m
@@ -247,13 +247,26 @@ const int kHookCount = sizeof(methodHooks) / sizeof(methodHooks[0]);
 @implementation Xcode_copy_line
 
 - (id)init {
-    const BOOL hookingSuccessful = (self = [super init]) && [self hookMethods];
-    if (!hookingSuccessful)
-        [self unhookMethods];
-    
-    NSLog(@"%@ %@", [self className], hookingSuccessful ? @"initialized" : @"failed to initialize");
+	// Hook into this notification in order to check menu items, since Xcode plugins get loaded in
+	//   applicationWillFinishLaunching as of 6.4.
+	[[NSNotificationCenter defaultCenter] addObserver:self
+											 selector:@selector(applicationDidFinishLaunching:)
+												 name:NSApplicationDidFinishLaunchingNotification
+											   object:nil];
     
     return self;
+}
+
+- (void)applicationDidFinishLaunching:(NSNotification *)notification {
+	const BOOL hookingSuccessful = (self = [super init]) && [self hookMethods];
+	if (!hookingSuccessful)
+		[self unhookMethods];
+	
+	NSLog(@"%@ %@", [self className], hookingSuccessful ? @"initialized" : @"failed to initialize");
+	
+	[[NSNotificationCenter defaultCenter] removeObserver:self
+													name:NSApplicationDidFinishLaunchingNotification
+												  object:nil];
 }
 
 - (BOOL)hookMethods {
@@ -262,6 +275,8 @@ const int kHookCount = sizeof(methodHooks) / sizeof(methodHooks[0]);
         cutMenuItem = [[editMenu submenu] itemWithTitle:@"Cut"];
         copyMenuItem = [[editMenu submenu] itemWithTitle:@"Copy"];
     }
+	
+	NSLog(@"EDIT MENU %@", [NSApp mainMenu]);
     
     if (!cutMenuItem) {
         NSLog(@"%@ ERROR: Unable to find Cut menu item", [self className]);

--- a/Xcode_copy_line.m
+++ b/Xcode_copy_line.m
@@ -276,8 +276,6 @@ const int kHookCount = sizeof(methodHooks) / sizeof(methodHooks[0]);
         copyMenuItem = [[editMenu submenu] itemWithTitle:@"Copy"];
     }
 	
-	NSLog(@"EDIT MENU %@", [NSApp mainMenu]);
-    
     if (!cutMenuItem) {
         NSLog(@"%@ ERROR: Unable to find Cut menu item", [self className]);
         return NO;

--- a/Xcode_copy_line.m
+++ b/Xcode_copy_line.m
@@ -247,26 +247,26 @@ const int kHookCount = sizeof(methodHooks) / sizeof(methodHooks[0]);
 @implementation Xcode_copy_line
 
 - (id)init {
-	// Hook into this notification in order to check menu items, since Xcode plugins get loaded in
-	//   applicationWillFinishLaunching as of 6.4.
-	[[NSNotificationCenter defaultCenter] addObserver:self
-											 selector:@selector(applicationDidFinishLaunching:)
-												 name:NSApplicationDidFinishLaunchingNotification
-											   object:nil];
+    // Hook into this notification in order to check menu items, since Xcode plugins get loaded in
+    //   applicationWillFinishLaunching as of 6.4.
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(applicationDidFinishLaunching:)
+                                                 name:NSApplicationDidFinishLaunchingNotification
+                                               object:nil];
     
     return self;
 }
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification {
-	const BOOL hookingSuccessful = (self = [super init]) && [self hookMethods];
-	if (!hookingSuccessful)
-		[self unhookMethods];
-	
-	NSLog(@"%@ %@", [self className], hookingSuccessful ? @"initialized" : @"failed to initialize");
-	
-	[[NSNotificationCenter defaultCenter] removeObserver:self
-													name:NSApplicationDidFinishLaunchingNotification
-												  object:nil];
+    const BOOL hookingSuccessful = (self = [super init]) && [self hookMethods];
+    if (!hookingSuccessful)
+        [self unhookMethods];
+    
+    NSLog(@"%@ %@", [self className], hookingSuccessful ? @"initialized" : @"failed to initialize");
+    
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:NSApplicationDidFinishLaunchingNotification
+                                                  object:nil];
 }
 
 - (BOOL)hookMethods {
@@ -275,7 +275,7 @@ const int kHookCount = sizeof(methodHooks) / sizeof(methodHooks[0]);
         cutMenuItem = [[editMenu submenu] itemWithTitle:@"Cut"];
         copyMenuItem = [[editMenu submenu] itemWithTitle:@"Copy"];
     }
-	
+
     if (!cutMenuItem) {
         NSLog(@"%@ ERROR: Unable to find Cut menu item", [self className]);
         return NO;


### PR DESCRIPTION
This fixes the issue I discovered in #7, and is backwards compatible with previous releases of Xcode 6.

As of Xcode 6.4, it seems plugins are now loaded in Xcode's `applicationWillFinishLaunching` method, which means that `[NSApp mainMenu]` isn't populated at plugin `init` time. What I've done is offload the command "binding" to a method that gets fired upon being notified of `NSApplicationDidFinishLaunchingNotification`. Voila!