### PR TITLE
Fix Line-Break Problem

### DIFF
--- a/Xcode_copy_line.m
+++ b/Xcode_copy_line.m
@@ -120,7 +120,7 @@ static void cutHook(id self_, SEL selector, id sender) {
         // Cut the current line.
         [self.undoManager beginUndoGrouping];
         [self xcl_markCursorPositionForUndo];
-        [self doCommandBySelector:@selector(selectLine:)];
+        [self doCommandBySelector:@selector(selectParagraph:)];
         [self doCommandBySelector:@selector(cut:)];
         [self.undoManager endUndoGrouping];
         


### PR DESCRIPTION
See https://github.com/mthiesen/Xcode_copy_line/issues/3.

Changing `selectLine:` to `selectParagraph:` seems to fix things without any side effects. Note: only briefly tested with Xcode 6.3.2.