### PR TITLE
Add Xcode 6.4b4, 6.4 GM, and 7b2 compat UUIDs.

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -41,6 +41,8 @@
 		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
 		<string>8DC44374-2B35-4C57-A6FE-2AD66A36AAD9</string>
 		<string>E969541F-E6F9-4D25-8158-72DC3545A6C6</string>
+		<string>AABB7188-E14E-4433-AD3B-5CD791EAD9A3</string>
+		<string>5EDAC44F-8E0B-42C9-9BEF-E9C12EEC4949</string>
 	</array>
 	<key>XC4Compatible</key>
 	<true/>

--- a/Info.plist
+++ b/Info.plist
@@ -43,6 +43,7 @@
 		<string>E969541F-E6F9-4D25-8158-72DC3545A6C6</string>
 		<string>AABB7188-E14E-4433-AD3B-5CD791EAD9A3</string>
 		<string>5EDAC44F-8E0B-42C9-9BEF-E9C12EEC4949</string>
+		<string>7FDF5C7A-131F-4ABB-9EDC-8C5F8F0B8A90</string>
 	</array>
 	<key>XC4Compatible</key>
 	<true/>


### PR DESCRIPTION
The UUID ending in `9A3` is the UUID for Xcode 7 Beta 2.

The UUID ending in `949` is the UUID for Xcode 6.4 Beta 4.

The UUID ending in `A90` is the UUID for Xcode 6.4 GM.